### PR TITLE
Fix the 0% SOC error.

### DIFF
--- a/Arduino/UGV/UGV.ino
+++ b/Arduino/UGV/UGV.ino
@@ -47,6 +47,7 @@ void setup(void) {
   Serial.begin(BAUD_RATE);
   // Joing I2C bus.
   Wire.begin();
+  delay(400);
 }
 
 // Auxiliar subroutines declaration


### PR DESCRIPTION
Previously, the Arduino board was, sometimes, sending a 0% of SOC value.
The reason is that the I2C communication has to spend some time to
initialize. That issue is solved now with a delay after the I2C
configuration (Wire.begin()) that ensure a time for setup the I2C
communication.

The value of the delay was set as 400 ms because the limit of the delay
that solve the problem is about 350 ms. With 400 ms, the Arduino board
always send a valid value of the battery SOC.